### PR TITLE
fix: nest spans correctly

### DIFF
--- a/DependencyInjection/GuzzleHandlerStackCompilerPass.php
+++ b/DependencyInjection/GuzzleHandlerStackCompilerPass.php
@@ -74,8 +74,8 @@ final class GuzzleHandlerStackCompilerPass implements CompilerPassInterface
         string $handlerServiceName
     ): void {
         if ($handlerDefinition->getClass() === HandlerStack::class) {
-            $handlerDefinition->addMethodCall('push', [new Reference(GuzzleTracingHeaderInjection::class)]);
             $handlerDefinition->addMethodCall('push', [new Reference(GuzzleRequestSpanning::class)]);
+            $handlerDefinition->addMethodCall('push', [new Reference(GuzzleTracingHeaderInjection::class)]);
             $clientDefinition->addTag('auxmoney_opentracing.enabled');
             return;
         }

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -11,5 +11,5 @@ services:
     class: GuzzleHttp\HandlerStack
     factory: ['GuzzleHttp\HandlerStack', 'create']
     calls:
-      - [push, ['@Auxmoney\OpentracingBundleGuzzle\Middleware\GuzzleTracingHeaderInjection']]
       - [push, ['@Auxmoney\OpentracingBundleGuzzle\Middleware\GuzzleRequestSpanning']]
+      - [push, ['@Auxmoney\OpentracingBundleGuzzle\Middleware\GuzzleTracingHeaderInjection']]


### PR DESCRIPTION
When fixing #2, the order of creating the surrounding span and injecting the tracing headers was wrong, resulting in incorrect nesting of spans. This PR fixes the order of the middleware.