### PR TITLE
Add guzzle promise onRejected handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.5.1](https://github.com/auxmoney/OpentracingBundle-Guzzle/compare/v0.5.0...v0.5.1) (2020-03-27)
+
+
+### Bug Fixes
+
+* upgrade core and documentation ([#14](https://github.com/auxmoney/OpentracingBundle-Guzzle/issues/14)) ([37b5c16](https://github.com/auxmoney/OpentracingBundle-Guzzle/commit/37b5c1609892fad0e78a88e0732af0b556e19372))
+
 # [0.5.0](https://github.com/auxmoney/OpentracingBundle-Guzzle/compare/v0.4.2...v0.5.0) (2020-03-20)
 
 

--- a/Middleware/GuzzleRequestSpanning.php
+++ b/Middleware/GuzzleRequestSpanning.php
@@ -6,6 +6,7 @@ namespace Auxmoney\OpentracingGuzzleBundle\Middleware;
 
 use Auxmoney\OpentracingBundle\Internal\Decorator\RequestSpanning;
 use Auxmoney\OpentracingBundle\Service\Tracing;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -30,11 +31,37 @@ final class GuzzleRequestSpanning
             $promise = $handler($request, $options);
             return $promise->then(
                 function (ResponseInterface $response) {
-                    $this->requestSpanning->finish($response->getStatusCode());
-                    $this->tracing->finishActiveSpan();
+                    $this->onFulfilled($response);
                     return $response;
+                },
+                function (RequestException $exception) {
+                    $this->onRejected($exception);
+                    throw $exception;
                 }
             );
         };
+    }
+
+    private function onFulfilled(ResponseInterface $response): void
+    {
+        $this->requestSpanning->finish($response->getStatusCode());
+        $this->tracing->finishActiveSpan();
+    }
+
+    private function onRejected(RequestException $exception): void
+    {
+        $this->tracing->logInActiveSpan(
+            [
+                'event' => 'error',
+                'error.kind' => 'Exception',
+                'error.object' => get_class($exception),
+                'message' => $exception->getMessage(),
+                'stack' => $exception->getTraceAsString(),
+            ]
+        );
+        if ($exception->hasResponse()) {
+            $this->requestSpanning->finish($exception->getResponse()->getStatusCode());
+        }
+        $this->tracing->finishActiveSpan();
     }
 }


### PR DESCRIPTION
This PR fixes #17 

It adds a `$onRejected` handler on guzzle promises.
This ensures the started spans are closed even when a promise is rejected.
